### PR TITLE
More description of the background map for the 'about' page

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,13 @@
 			<p>We love your feedback. Say <a href="mailto:hello@mapgrams.com">hello@mapgrams.com</a> or fork it on <a href="https://github.com/rsudekum/MapGrams">Github</a></p>
 			<h6 style="font-size:10px; margin:40px">Data provided by <a href="http://www.openstreetmap.org/">Open Street Maps</a>, map tiles by <a href="http://www.mapbox.com">Mapbox</a> and powered by <a href="http://www.leaflet.cloudmade.com">Leaflet</a>. Created by <a href="http://visuallybs.com">Bobby Sudekum</a></h6> 
 
+			<h6 style="font-size:10px; margin:40px">The background map was created by thousands of volunteer contributors to the OpenStreetMap project - The free wiki world map.
+			OpenStreetMap is not-for-profit, with a mission to map the whole world and release the data for free with an open license (<a href="http://creativecommons.org/licenses/by-sa/2.0/" title="Creative Commons Attribution Sharealike 2.0">CC-BY-SA</a>)
+			See something missing? You can edit the map and contribute your local knowledge at  <a href="http://www.openstreetmap.org/">OpenStreetMap.org</a>.
+			Map tiles by <a href="http://www.mapbox.com">Mapbox</a> and presented using <a href="http://www.leaflet.cloudmade.com">Leaflet</a></h6>
+			
+			<h6 style="font-size:10px; margin:40px">Created by <a href="http://visuallybs.com">Bobby Sudekum</a></h6> 
+
 		</div>
 
 	<div class="show_hide">Explore other places!</div> 


### PR DESCRIPTION
It's "OpenStreetMap" not "Open Street Maps", and you're required to mention the CC-BY-SA2.0 license

but hey... you've got some space on this tucked away 'about' page. Why not go for a little more explanation while we're about it? 
